### PR TITLE
Add asset uploader Rake task

### DIFF
--- a/lib/tasks/upload_assets.rake
+++ b/lib/tasks/upload_assets.rake
@@ -1,0 +1,22 @@
+namespace :assets do
+  desc "Import assets"
+  task :upload => :environment do
+    Asset.all.each do |asset|
+      origin = asset.source
+      service = Fog::Storage.new({
+                    :provider            => 'Rackspace',
+                    :rackspace_username  => ENV['RACKSPACE_USERNAME'],
+                    :rackspace_api_key   => ENV['RACKSPACE_API_KEY'],
+                    :rackspace_auth_url  => Fog::Rackspace::UK_AUTH_ENDPOINT,
+                    :rackspace_region    => :lon
+                })
+      
+      dir = service.directories.get ENV['QUIRKAFLEEG_ASSET_MANAGER_RACKSPACE_CONTAINER']
+      id = asset.id.to_s
+      filename = "uploads/assets/#{id[2..3]}/#{id[4..5]}/#{id}/#{asset.title}"
+      body = open(origin)
+      
+      dir.files.create :key => filename, :body => body
+    end 
+  end
+end


### PR DESCRIPTION
This adds a Rake task to take the assets from the exports and upload them to the right place. In the raw DB export, they're referenced, but not actually uploaded.
