### PR TITLE
Dockerizing...

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,10 +1,10 @@
 development:
-  host: localhost
+  host: <%= ENV['MONGOID_HOST'] ||= "localhost" %>
   database: govuk_assets_development
   persist_in_safe_mode: true
 
 test:
-  host: localhost
+  host: <%= ENV['MONGOID_HOST'] ||= "localhost" %>
   database: govuk_assets_test
 
 # set these environment variables on your prod server


### PR DESCRIPTION
`MONGOID_HOST` now provides hostname for mongo database, defaults to `localhost`.