### PR TITLE
Removing dependency on gemfury

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-source 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
 
 #ruby=ruby-1.9.3
 #ruby-gemset=asset-manager
@@ -31,7 +30,7 @@ gem 'mini_magick'
 if ENV['BUNDLE_DEV']
   gem 'gds-sso', path: '../gds-sso'
 else
-  gem 'gds-sso', '3.0.0'
+  gem 'gds-sso', '3.0.5'
 end
 
 gem 'plek', '1.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,5 @@
 GEM
   remote: https://rubygems.org/
-  remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
   specs:
     CFPropertyList (2.3.1)
     actionmailer (3.2.22)
@@ -59,15 +58,15 @@ GEM
       mongoid (>= 2.0)
     diff-lcs (1.1.3)
     docile (1.1.5)
-    dotenv (2.0.1)
-    dotenv-rails (2.0.1)
-      dotenv (= 2.0.1)
+    dotenv (0.7.0)
+    dotenv-rails (0.7.0)
+      dotenv (= 0.7.0)
     erubis (2.7.0)
-    eventmachine (1.0.7)
+    eventmachine (1.0.8)
     exception_notification (2.6.1)
       actionmailer (>= 3.0.4)
     excon (0.45.4)
-    execjs (2.5.2)
+    execjs (2.6.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.5.0)
@@ -77,11 +76,12 @@ GEM
       multipart-post (>= 1.2, < 3)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.32.0)
+    fog (1.33.0)
       fog-atmos
       fog-aws (>= 0.6.0)
       fog-brightbox (~> 0.4)
       fog-core (~> 1.32)
+      fog-dynect
       fog-ecloud (= 0.1.1)
       fog-google (>= 0.0.2)
       fog-json
@@ -108,17 +108,21 @@ GEM
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.8.0)
+    fog-brightbox (0.9.0)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.32.0)
+    fog-core (1.32.1)
       builder
       excon (~> 0.45)
       formatador (~> 0.2)
       mime-types
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
+    fog-dynect (0.0.1)
+      fog-core
+      fog-json
+      fog-xml
     fog-ecloud (0.1.1)
       fog-core
       fog-xml
@@ -171,12 +175,12 @@ GEM
     fog-xml (0.1.2)
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
-    foreman (0.63.0)
-      dotenv (>= 0.7)
+    foreman (0.64.0)
+      dotenv (~> 0.7.0)
       thor (>= 0.13.6)
     formatador (0.2.5)
-    gds-sso (3.0.0)
-      omniauth-gds (= 0.0.3)
+    gds-sso (3.0.5)
+      omniauth-gds (~> 0.0.3)
       rack-accept (~> 0.4.4)
       rails (>= 3.0.0)
       warden (~> 1.2)
@@ -193,7 +197,7 @@ GEM
       treetop (~> 1.4.8)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_magick (4.2.9)
+    mini_magick (4.2.10)
     mini_portile (0.6.2)
     mongo (1.6.2)
       bson (~> 1.6.2)
@@ -221,7 +225,7 @@ GEM
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
       rack (~> 1.0)
-    omniauth-gds (0.0.3)
+    omniauth-gds (0.0.4)
       omniauth-oauth2 (~> 1.0)
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
@@ -318,7 +322,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.0)
   fog (>= 1.16.0)
   foreman (< 0.65.0)
-  gds-sso (= 3.0.0)
+  gds-sso (= 3.0.5)
   mini_magick
   mongoid (= 2.4.12)
   mongoid_spacial
@@ -330,3 +334,6 @@ DEPENDENCIES
   state_machine (= 1.1.2)
   thin
   uglifier (>= 1.0.3)
+
+BUNDLED WITH
+   1.10.5


### PR DESCRIPTION
Gemfury seems to have stopped working, and in any case causes potential
issues with duplicate sources. This fix removes the gemfury source
and resolves an issue with gds-sso